### PR TITLE
Add support for zita 4.0

### DIFF
--- a/ambix_binaural/Source/PluginProcessor.cpp
+++ b/ambix_binaural/Source/PluginProcessor.cpp
@@ -924,9 +924,9 @@ void Ambix_binauralAudioProcessor::LoadConfiguration(File configFile)
         options |= Convproc::OPT_VECTOR_MODE;
         
         zita_conv.set_options (options);
-        zita_conv.set_density(0.5);
+        const float density = 0.5f;
                 
-        err = zita_conv.configure(conv_data.getNumInputChannels(), conv_data.getNumOutputChannels(), (unsigned int)conv_data.getMaxLength(), ConvBufferSize, ConvBufferSize, Convproc::MAXPART);
+        err = zita_conv.configure(conv_data.getNumInputChannels(), conv_data.getNumOutputChannels(), (unsigned int)conv_data.getMaxLength(), ConvBufferSize,Convproc::MINPART, Convproc::MAXPART, density);
         
         for (int i=0; i < conv_data.getNumIRs(); i++)
         {

--- a/ambix_binaural/Source/PluginProcessor.h
+++ b/ambix_binaural/Source/PluginProcessor.h
@@ -26,9 +26,6 @@
 #if BINAURAL_DECODER
     #if WITH_ZITA_CONVOLVER
         #include <zita-convolver.h>
-        #if ZITA_CONVOLVER_MAJOR_VERSION != 3
-            #error "This programs requires zita-convolver 3.x.x"
-        #endif
         
         #define CONVPROC_SCHEDULER_PRIORITY 0
         #define CONVPROC_SCHEDULER_CLASS SCHED_FIFO


### PR DESCRIPTION
This could address issue #23. I was unable to test as I do not have ambisonic recordings at hands.
It does compile.