### PR TITLE
Setting JucePlugin_LV2URI to a real URI.

### DIFF
--- a/ambix_binaural/JuceLibraryCode/AppConfig.h
+++ b/ambix_binaural/JuceLibraryCode/AppConfig.h
@@ -344,7 +344,7 @@
 #endif
 
 #ifndef JucePlugin_LV2URI
-	#define JucePlugin_LV2URI               JucePlugin_Name
+	#define JucePlugin_LV2URI               "https://github.com/kronihias/ambix/ambix_binaural"
 #endif
 #ifndef JucePlugin_WantsLV2State
 	#define JucePlugin_WantsLV2State        1

--- a/ambix_converter/JuceLibraryCode/AppConfig.h
+++ b/ambix_converter/JuceLibraryCode/AppConfig.h
@@ -320,7 +320,7 @@
 #endif
 
 #ifndef JucePlugin_LV2URI
-  #define JucePlugin_LV2URI               JucePlugin_Name
+  #define JucePlugin_LV2URI               "https://github.com/kronihias/ambix/ambix_converter"
 #endif
 #ifndef JucePlugin_WantsLV2State
   #define JucePlugin_WantsLV2State        1

--- a/ambix_decoder/ambix_decoder/CMakeLists.txt
+++ b/ambix_decoder/ambix_decoder/CMakeLists.txt
@@ -4,6 +4,7 @@ SET ( WITH_FFTW3 FALSE )
 
 # binaural
 ADD_DEFINITIONS (-DBINAURAL_DECODER=0)
+ADD_DEFINITIONS(-DJucePlugin_LV2URI="https://github.com/kronihias/ambix/ambix_decoder")
 SET ( SPECIFIC_PROJECTNAME ambix_decoder )
 
 SET ( SPECIFIC_SOURE_DIR ${SRC_DIR}/ambix_binaural )

--- a/ambix_directional_loudness/JuceLibraryCode/AppConfig.h
+++ b/ambix_directional_loudness/JuceLibraryCode/AppConfig.h
@@ -271,7 +271,7 @@
 #endif
 
 #ifndef JucePlugin_LV2URI
-	#define JucePlugin_LV2URI               JucePlugin_Name
+	#define JucePlugin_LV2URI               "https://github.com/kronihias/ambix/ambix_directional_loudness"
 #endif
 #ifndef JucePlugin_WantsLV2State
 #define JucePlugin_WantsLV2State        1

--- a/ambix_encoder/JuceLibraryCode/AppConfig.h
+++ b/ambix_encoder/JuceLibraryCode/AppConfig.h
@@ -333,7 +333,7 @@
 #endif
 
 #ifndef JucePlugin_LV2URI
-  #define JucePlugin_LV2URI               JucePlugin_Name
+  #define JucePlugin_LV2URI               "https://github.com/kronihias/ambix/ambix_encoder"
 #endif
 #ifndef JucePlugin_WantsLV2State
   #define JucePlugin_WantsLV2State        1

--- a/ambix_encoder/ambix_encoder_i2/CMakeLists.txt
+++ b/ambix_encoder/ambix_encoder_i2/CMakeLists.txt
@@ -3,6 +3,7 @@ SET( WITH_SphericalHarmonic TRUE )
 SET ( WITH_MyMeterDsp TRUE )
 
 ADD_DEFINITIONS(-DINPUT_CHANNELS=2)
+ADD_DEFINITIONS(-DJucePlugin_LV2URI="https://github.com/kronihias/ambix/ambix_encoder_i2")
 
 # SET ( SPECIFIC_PROJECTNAME ambix_encoder )
 SET ( SPECIFIC_SOURE_DIR ${SRC_DIR}/ambix_encoder )

--- a/ambix_encoder/ambix_encoder_i4/CMakeLists.txt
+++ b/ambix_encoder/ambix_encoder_i4/CMakeLists.txt
@@ -3,6 +3,7 @@ SET( WITH_SphericalHarmonic TRUE )
 SET ( WITH_MyMeterDsp TRUE )
 
 ADD_DEFINITIONS(-DINPUT_CHANNELS=4)
+ADD_DEFINITIONS(-DJucePlugin_LV2URI="https://github.com/kronihias/ambix/ambix_encoder_i4")
 
 # SET ( SPECIFIC_PROJECTNAME ambix_encoder )
 SET ( SPECIFIC_SOURE_DIR ${SRC_DIR}/ambix_encoder )

--- a/ambix_encoder/ambix_encoder_i6/CMakeLists.txt
+++ b/ambix_encoder/ambix_encoder_i6/CMakeLists.txt
@@ -3,6 +3,7 @@ SET( WITH_SphericalHarmonic TRUE )
 SET ( WITH_MyMeterDsp TRUE )
 
 ADD_DEFINITIONS(-DINPUT_CHANNELS=6)
+ADD_DEFINITIONS(-DJucePlugin_LV2URI="https://github.com/kronihias/ambix/ambix_encoder_i6")
 
 # SET ( SPECIFIC_PROJECTNAME ambix_encoder )
 SET ( SPECIFIC_SOURE_DIR ${SRC_DIR}/ambix_encoder )

--- a/ambix_encoder/ambix_encoder_i8/CMakeLists.txt
+++ b/ambix_encoder/ambix_encoder_i8/CMakeLists.txt
@@ -3,6 +3,7 @@ SET( WITH_SphericalHarmonic TRUE )
 SET ( WITH_MyMeterDsp TRUE )
 
 ADD_DEFINITIONS(-DINPUT_CHANNELS=8)
+ADD_DEFINITIONS(-DJucePlugin_LV2URI="https://github.com/kronihias/ambix/ambix_encoder_i8")
 
 # SET ( SPECIFIC_PROJECTNAME ambix_encoder )
 SET ( SPECIFIC_SOURE_DIR ${SRC_DIR}/ambix_encoder )

--- a/ambix_maxre/JuceLibraryCode/AppConfig.h
+++ b/ambix_maxre/JuceLibraryCode/AppConfig.h
@@ -354,7 +354,7 @@
 #endif
 
 #ifndef JucePlugin_LV2URI
-#define JucePlugin_LV2URI               JucePlugin_Name
+#define JucePlugin_LV2URI               "https://github.com/kronihias/ambix/ambix_maxre"
 #endif
 #ifndef JucePlugin_WantsLV2State
 #define JucePlugin_WantsLV2State        1

--- a/ambix_mirror/JuceLibraryCode/AppConfig.h
+++ b/ambix_mirror/JuceLibraryCode/AppConfig.h
@@ -343,7 +343,7 @@
 
 
 #ifndef JucePlugin_LV2URI
-  #define JucePlugin_LV2URI               JucePlugin_Name
+  #define JucePlugin_LV2URI               "https://github.com/kronihias/ambix/ambix_mirror"
 #endif
 #ifndef JucePlugin_WantsLV2State
   #define JucePlugin_WantsLV2State        1

--- a/ambix_rotator/JuceLibraryCode/AppConfig.h
+++ b/ambix_rotator/JuceLibraryCode/AppConfig.h
@@ -266,7 +266,7 @@
 #endif
 
 #ifndef JucePlugin_LV2URI
-  #define JucePlugin_LV2URI               JucePlugin_Name
+  #define JucePlugin_LV2URI               "https://github.com/kronihias/ambix/ambix_rotator"
 #endif
 #ifndef JucePlugin_WantsLV2State
   #define JucePlugin_WantsLV2State        1

--- a/ambix_rotator_z/JuceLibraryCode/AppConfig.h
+++ b/ambix_rotator_z/JuceLibraryCode/AppConfig.h
@@ -341,7 +341,7 @@
 #endif
 
 #ifndef JucePlugin_LV2URI
-  #define JucePlugin_LV2URI               JucePlugin_Name
+  #define JucePlugin_LV2URI               "https://github.com/kronihias/ambix/ambix_rotator_z"
 #endif
 #ifndef JucePlugin_WantsLV2State
   #define JucePlugin_WantsLV2State        1

--- a/ambix_vmic/JuceLibraryCode/AppConfig.h
+++ b/ambix_vmic/JuceLibraryCode/AppConfig.h
@@ -269,7 +269,7 @@
 #endif
 
 #ifndef JucePlugin_LV2URI
-  #define JucePlugin_LV2URI               JucePlugin_Name
+  #define JucePlugin_LV2URI               "https://github.com/kronihias/ambix/ambix_vmic"
 #endif
 #ifndef JucePlugin_WantsLV2State
   #define JucePlugin_WantsLV2State        1

--- a/ambix_warp/JuceLibraryCode/AppConfig.h
+++ b/ambix_warp/JuceLibraryCode/AppConfig.h
@@ -291,7 +291,7 @@
 #endif
 
 #ifndef JucePlugin_LV2URI
-  #define JucePlugin_LV2URI               JucePlugin_Name
+  #define JucePlugin_LV2URI               "https://github.com/kronihias/ambix/ambix_warp"
 #endif
 #ifndef JucePlugin_WantsLV2State
   #define JucePlugin_WantsLV2State        1

--- a/ambix_widening/JuceLibraryCode/AppConfig.h
+++ b/ambix_widening/JuceLibraryCode/AppConfig.h
@@ -357,7 +357,7 @@
 #endif
 
 #ifndef JucePlugin_LV2URI
-  #define JucePlugin_LV2URI               JucePlugin_Name
+  #define JucePlugin_LV2URI               "https://github.com/kronihias/ambix/ambix_widening"
 #endif
 #ifndef JucePlugin_WantsLV2State
   #define JucePlugin_WantsLV2State        1


### PR DESCRIPTION
ambix_*/JuceLibraryCode/AppConfig.h:
Switching from using 'JucePlugin_Name' as JucePlugin_LV2URI to a 'real'
URI, so that lv2 hosts can actually discover and use the plugins and not
crash on them.

Note: The URI does not have to be a 'real' URI (as in: an existing
website), but needs to follow the established URI scheme to be
recognized.

Closes #27