### PR TITLE
Fix build with gcc >= 9.1.0

### DIFF
--- a/JUCE/modules/juce_graphics/colour/juce_PixelFormats.h
+++ b/JUCE/modules/juce_graphics/colour/juce_PixelFormats.h
@@ -108,19 +108,6 @@ public:
     forcedinline uint8 getGreen() const noexcept      { return components.g; }
     forcedinline uint8 getBlue() const noexcept       { return components.b; }
 
-   #if JUCE_GCC
-    // NB these are here as a workaround because GCC refuses to bind to packed values.
-    forcedinline uint8& getAlpha() noexcept           { return comps [indexA]; }
-    forcedinline uint8& getRed() noexcept             { return comps [indexR]; }
-    forcedinline uint8& getGreen() noexcept           { return comps [indexG]; }
-    forcedinline uint8& getBlue() noexcept            { return comps [indexB]; }
-   #else
-    forcedinline uint8& getAlpha() noexcept           { return components.a; }
-    forcedinline uint8& getRed() noexcept             { return components.r; }
-    forcedinline uint8& getGreen() noexcept           { return components.g; }
-    forcedinline uint8& getBlue() noexcept            { return components.b; }
-   #endif
-
     //==============================================================================
     /** Copies another pixel colour over this one.
 
@@ -339,9 +326,6 @@ private:
     {
         uint32 internal;
         Components components;
-       #if JUCE_GCC
-        uint8 comps[4];  // helper struct needed because gcc does not allow references to packed union members
-       #endif
     };
 }
 #ifndef DOXYGEN

--- a/JUCE/modules/juce_graphics/native/juce_RenderingHelpers.h
+++ b/JUCE/modules/juce_graphics/native/juce_RenderingHelpers.h
@@ -580,18 +580,10 @@ namespace EdgeTableFillers
             : destData (image), sourceColour (colour)
         {
             if (sizeof (PixelType) == 3 && destData.pixelStride == sizeof (PixelType))
-            {
                 areRGBComponentsEqual = sourceColour.getRed() == sourceColour.getGreen()
                                             && sourceColour.getGreen() == sourceColour.getBlue();
-                filler[0].set (sourceColour);
-                filler[1].set (sourceColour);
-                filler[2].set (sourceColour);
-                filler[3].set (sourceColour);
-            }
             else
-            {
                 areRGBComponentsEqual = false;
-            }
         }
 
         forcedinline void setEdgeTableYPos (const int y) noexcept
@@ -642,7 +634,6 @@ namespace EdgeTableFillers
         const Image::BitmapData& destData;
         PixelType* linePixels;
         PixelARGB sourceColour;
-        PixelRGB filler [4];
         bool areRGBComponentsEqual;
 
         forcedinline PixelType* getPixel (const int x) const noexcept
@@ -657,47 +648,10 @@ namespace EdgeTableFillers
 
         forcedinline void replaceLine (PixelRGB* dest, const PixelARGB colour, int width) const noexcept
         {
-            if (destData.pixelStride == sizeof (*dest))
-            {
-                if (areRGBComponentsEqual)  // if all the component values are the same, we can cheat..
-                {
-                    memset (dest, colour.getRed(), (size_t) width * 3);
-                }
-                else
-                {
-                    if (width >> 5)
-                    {
-                        const int* const intFiller = reinterpret_cast<const int*> (filler);
-
-                        while (width > 8 && (((pointer_sized_int) dest) & 7) != 0)
-                        {
-                            dest->set (colour);
-                            ++dest;
-                            --width;
-                        }
-
-                        while (width > 4)
-                        {
-                            int* d = reinterpret_cast<int*> (dest);
-                            *d++ = intFiller[0];
-                            *d++ = intFiller[1];
-                            *d++ = intFiller[2];
-                            dest = reinterpret_cast<PixelRGB*> (d);
-                            width -= 4;
-                        }
-                    }
-
-                    while (--width >= 0)
-                    {
-                        dest->set (colour);
-                        ++dest;
-                    }
-                }
-            }
+            if ((size_t) destData.pixelStride == sizeof (*dest) && areRGBComponentsEqual)
+                              memset ((void*) dest, colour.getRed(), (size_t) width * 3);   // if all the component values are the same, we can cheat..
             else
-            {
                 JUCE_PERFORM_PIXEL_OP_LOOP (set (colour))
-            }
         }
 
         forcedinline void replaceLine (PixelAlpha* dest, const PixelARGB colour, int width) const noexcept


### PR DESCRIPTION
JUCE/modules/juce_graphics/*:
Backport of
https://github.com/juce-framework/JUCE/commit/4e0adb2af8b424c43d22bd431011c9a6c57d36b6
to be able to compile with gcc >= 9.1.0.

Fixes #26